### PR TITLE
Linux Support Added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ coverage.xml
 
 # Virtual Environment
 venv/
+.venv/

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Type `exit` or `quit` to leave the command prompt.
 
 ## For Linux Users
 
-SPecially for Ubuntu 22 and above those needs to use `python env` add below line into your `~/.bashrc` file
+Specially for Ubuntu 22 and above those needs to use `python env` add below line into your `~/.bashrc` file. Please modify the path to `initialterm/start.sh` based on your file location.
 
 ```bash
-alias aiterminal='/home/tyson/initialterm/start.sh'
+alias aiterminal='/PATH/TO/HOME/initialterm/start.sh'
 ```
 
 After adding the alias, reload your `~/.bashrc` file to apply the changes: 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ This will start the custom command prompt where you can enter your queries. The 
 
 Type `exit` or `quit` to leave the command prompt.
 
+## For Linux Users
+
+SPecially for Ubuntu 22 and above those needs to use `python env` add below line into your `~/.bashrc` file
+
+```bash
+alias aiterminal='/home/tyson/initialterm/start.sh'
+```
+
+After adding the alias, reload your `~/.bashrc` file to apply the changes: 
+
+```bash
+source ~/.bashrc
+```
+
+Now open your terminal and Just type the command: `aiterminal`
+
 ## Contributing
 
 We welcome contributions to InitialTerm! If you'd like to contribute, please follow these guidelines:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Type `exit` or `quit` to leave the command prompt.
 
 ## For Linux Users
 
+To install InitialTerm in editable mode, use the following command:
+
+```bash
+source .venv/bin/activate
+```
+
+```bash
+pip install -e .
+```
+
 Specially for Ubuntu 22 and above those needs to use `python env` add below line into your `~/.bashrc` file. Please modify the path to `initialterm/start.sh` based on your file location.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ After adding the alias, reload your `~/.bashrc` file to apply the changes:
 source ~/.bashrc
 ```
 
-Now open your terminal and Just type the command: `aiterminal`
+Now open your terminal and Just type the command: 
+
+```bash
+aiterminal
+```
 
 ## Contributing
 

--- a/initialterm/main.py
+++ b/initialterm/main.py
@@ -126,12 +126,12 @@ def start_custom_cmd(model_name='llama3.2:3b'):
     import platform
     os_name = platform.system()
     
-    if os_name not in ['Windows', 'Darwin']:
-        logging.error("Unsupported OS. This script is designed for Windows and macOS.")
-        print("Unsupported OS. This script is designed for Windows and macOS.")
+    if os_name not in ['Windows', 'Darwin', 'Linux']:
+        logging.error("Unsupported OS. This script is designed for Windows, macOS, and Linux.")
+        print("Unsupported OS. This script is designed for Windows, macOS, and Linux.")
         return
     
-    os_name = 'MacOS' if os_name == 'Darwin' else 'Windows'
+    os_name = 'MacOS' if os_name == 'Darwin' else 'Linux' if os_name == 'Linux' else 'Windows'
     
     custom_cmd(os_name, model_name)
 

--- a/initialterm/main.py
+++ b/initialterm/main.py
@@ -131,7 +131,13 @@ def start_custom_cmd(model_name='llama3.2:3b'):
         print("Unsupported OS. This script is designed for Windows, macOS, and Linux.")
         return
     
-    os_name = 'MacOS' if os_name == 'Darwin' else 'Linux' if os_name == 'Linux' else 'Windows'
+    os_name_mapping = {
+        'Darwin': 'MacOS',
+        'Linux': 'Linux',
+        'Windows': 'Windows'
+    }
+    
+    os_name = os_name_mapping.get(os_name, 'Unsupported OS')
     
     custom_cmd(os_name, model_name)
 

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Activate the Python environment
-source /home/tyson/initialterm/.venv/bin/activate
+source ./initialterm/.venv/bin/activate
 
 # Start the initialterm command
 initialterm

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Activate the Python environment
-source ./initialterm/.venv/bin/activate
+source ~/initialterm/.venv/bin/activate
 
 # Start the initialterm command
 initialterm

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Activate the Python environment
+source /home/tyson/initialterm/.venv/bin/activate
+
+# Start the initialterm command
+initialterm


### PR DESCRIPTION
### For Linux Users
To install InitialTerm in editable mode, use the following command:

```
source .venv/bin/activate
pip install -e .
```

Specially for Ubuntu 22 and above those needs to use python env add below line into your ~/.bashrc file. Please modify the path to initialterm/start.sh based on your file location.

`alias aiterminal='/PATH/TO/HOME/initialterm/start.sh'`

After adding the alias, reload your ~/.bashrc file to apply the changes: `source ~/.bashrc`

Now open your terminal and Just type the command: `aiterminal`